### PR TITLE
ART: force GCC 4.8 for build

### DIFF
--- a/compiler/Android.mk
+++ b/compiler/Android.mk
@@ -194,6 +194,11 @@ define build-libart-compiler
     LOCAL_SHARED_LIBRARIES += libartd
   endif
 
+  ifeq ($$(art_target_or_host),target)
+    LOCAL_CC  := $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-gcc$$(HOST_EXECUTABLE_SUFFIX)
+    LOCAL_CXX := $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++$$(HOST_EXECUTABLE_SUFFIX)
+  endif
+
   LOCAL_MODULE_TAGS := optional
   LOCAL_MODULE_CLASS := SHARED_LIBRARIES
 

--- a/runtime/Android.mk
+++ b/runtime/Android.mk
@@ -399,9 +399,13 @@ $$(ENUM_OPERATOR_OUT_GEN): $$(GENERATED_SRC_DIR)/%_operator_out.cc : $(LOCAL_PAT
     # TODO: Loop with ifeq, ART_TARGET_CLANG
     ifneq ($$(ART_TARGET_CLANG_$$(TARGET_ARCH)),true)
       LOCAL_SRC_FILES_$$(TARGET_ARCH) += $$(LIBART_GCC_ONLY_SRC_FILES)
+      LOCAL_CC  := $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-gcc$$(HOST_EXECUTABLE_SUFFIX)
+      LOCAL_CXX := $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++$$(HOST_EXECUTABLE_SUFFIX)
     endif
     ifneq ($$(ART_TARGET_CLANG_$$(TARGET_2ND_ARCH)),true)
       LOCAL_SRC_FILES_$$(TARGET_2ND_ARCH) += $$(LIBART_GCC_ONLY_SRC_FILES)
+      LOCAL_CC  := $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-gcc$$(HOST_EXECUTABLE_SUFFIX)
+      LOCAL_CXX := $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++$$(HOST_EXECUTABLE_SUFFIX)
     endif
   else # host
     LOCAL_CLANG := $$(ART_HOST_CLANG)


### PR DESCRIPTION
GCC 4.9 causes ridiculous segfaults on at least ARM targets for ART.

Change-Id: I51cd3398e69770c00431f5564e19e563c941d6b3

Google apparently has a fix :
https://android.googlesource.com/platform/art/+/376b2bbf7c39108223a7a01568a7b4b04d84eeac

But for some reason, not solves the issue; at least on Android 5.0 Lollipop.

So force GCC 4.8 for now.

Patch-set 2:

 - Fix whitespaces
 - Add 4.8 override to the libart-compiler as well
 - Remove 4.8 override to build & dex2oat

Signed-off-by: arter97 <qkrwngud825@gmail.com>